### PR TITLE
Extends propTypes and defaultProps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,8 @@ export const createConnect = store => (...configs) => (WrappedComponent) => {
   }
   const contextTypes = ConnectedComponent.contextTypes || {};
   ConnectWrapper.contextTypes = { ...contextTypes, store: object };
+  ConnectWrapper.propTypes = WrappedComponent.propTypes;
+  ConnectWrapper.defaultProps = WrappedComponent.defaultProps;
   return ConnectWrapper;
 };
 


### PR DESCRIPTION
This will allow send props from angularjs to React components using react2angular

"Note: If you defined propTypes on your component, they will be used to compute component's bindings, and you can omit the 2nd argument:"